### PR TITLE
chore: use `typescript-eslint/no-unused-vars` inside eslint

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sundae/eslint-config",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "eslint config from which all other eslint-configs inherit from.",
   "main": "dist/index.js",
   "files": [

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -84,7 +84,6 @@ export const rules = {
     },
   ],
   "no-unused-labels": "warn",
-  "no-unused-vars": "error",
   "no-use-before-define": [
     "warn",
     {
@@ -116,4 +115,5 @@ export const rules = {
   "getter-return": "warn",
   "prettier/prettier": "error",
   "@typescript-eslint/no-explicit-any": "error",
+  "@typescript-eslint/no-unused-vars": "error",
 };


### PR DESCRIPTION
## Problem
Extending `@sundae/eslint-config` throws an error for `enum` even though their values are used across the application:

<img width="268" alt="Bildschirmfoto 2022-05-20 um 12 27 44" src="https://user-images.githubusercontent.com/14215432/169509189-96f9b39e-7a7a-4e8f-8ea9-0a7b8dd60dfd.png">

## Solution
Instead of using the rule `no-unused-vars`, we prefer using `@typescript-eslint/no-unused-vars`
