### PR TITLE
chore: remove purgecss

### DIFF
--- a/packages/postcss-config/package.json
+++ b/packages/postcss-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sundae/postcss-config",
-  "version": "1.3.1",
+  "version": "1.4",
   "description": "basic postcss config options for SundaeSwap projects.",
   "keywords": [
     "postcss",
@@ -23,7 +23,6 @@
     "test": "yarn run build"
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^4.1.3",
     "postcss": "^8.4.14",
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^7.6.0",

--- a/packages/postcss-config/src/index.ts
+++ b/packages/postcss-config/src/index.ts
@@ -1,46 +1,15 @@
-import path from "path";
-import glob from "glob";
-import purgecss from "@fullhuman/postcss-purgecss";
 import normalize from "postcss-normalize";
-
-type TPurgecssOptions = Parameters<typeof purgecss>[0];
 
 export type TPostCSSConfigFactoryProps = {
   useScss?: boolean;
-  purgeCssOpts?:
-    | TPurgecssOptions
-    | ((opts?: TPurgecssOptions) => TPurgecssOptions);
 };
 
 export const getConfig = ({
   useScss = true,
-  purgeCssOpts,
 }: TPostCSSConfigFactoryProps = {}) => {
-  const purgeDefaults: TPurgecssOptions = {
-    defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
-    content: [
-      path.join(process.cwd(), "./dist/index.html"), //to match index.html
-      ...glob.sync(
-        `${path.join(process.cwd(), "src")}/**/*.tsx`, //to match React JSX files in src/components/*.jsx
-        { nodir: true }
-      ),
-    ],
-  };
-
   return {
     ident: "postcss",
     syntax: useScss ? "postcss-scss" : "postcss-safe-parser",
-    plugins: [
-      "postcss-preset-env",
-      normalize(),
-      require("tailwindcss"),
-      process.env.NODE_ENV === "production"
-        ? purgecss(
-            typeof purgeCssOpts === "function"
-              ? purgeCssOpts(purgeDefaults)
-              : { ...purgeDefaults, ...purgeCssOpts }
-          )
-        : null,
-    ],
+    plugins: ["postcss-preset-env", normalize(), require("tailwindcss")],
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,13 +568,6 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fullhuman/postcss-purgecss@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz#e4eb21fc7a49257e4081c6a3a86b338618e61fce"
-  integrity sha512-jqcsyfvq09VOsMXxJMPLRF6Fhg/NNltzWKnC9qtzva+QKTxerCO4esG6je7hbnmkpZtaDyPTwMBj9bzfWorsrw==
-  dependencies:
-    purgecss "^4.1.3"
-
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -3457,7 +3450,7 @@ commander@^7.0.0, commander@^7.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-commander@^8.0.0, commander@^8.3.0:
+commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
@@ -5191,7 +5184,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -9012,16 +9005,6 @@ pupa@^2.1.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
-
-purgecss@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-4.1.3.tgz#683f6a133c8c4de7aa82fe2746d1393b214918f7"
-  integrity sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==
-  dependencies:
-    commander "^8.0.0"
-    glob "^7.1.7"
-    postcss "^8.3.5"
-    postcss-selector-parser "^6.0.6"
 
 q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Removes PurgeCSS tooling since TailwindCSS 3+ does this by itself on production builds.