### PR TITLE
Fix @sundaeswap/prettier-config package metadata links

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@sundaeswap/prettier-config",
   "version": "2.0.13",
-  "repository": "https://github.com/sundaeswap-finance/frontend-configurations/tree/master/packages/prettier-config",
+  "homepage": "https://github.com/SundaeSwap-finance/frontend-configurations/tree/main/packages/prettier-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SundaeSwap-finance/frontend-configurations.git",
+    "directory": "packages/prettier-config"
+  },
+  "bugs": {
+    "url": "https://github.com/SundaeSwap-finance/frontend-configurations/issues"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
## Summary
- point the `@sundaeswap/prettier-config` homepage at the package directory on the current `main` branch
- replace the package-level repository string with a standard repository object
- add `repository.directory` and `bugs.url` metadata for npm users

## Validation
- `node` package metadata assertion for `homepage`, `repository`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` from `packages/prettier-config`
- `git diff --check`
