### PR TITLE
fix(deps): reconcile bun.lock so the v4 publish can ship

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,8 +93,6 @@
         "postcss": "^8.4.14",
         "postcss-load-config": "^6.0.1",
         "postcss-normalize": "^10.0.1",
-        "postcss-safe-parser": "^7.0.0",
-        "postcss-scss": "^4.0.4",
       },
       "devDependencies": {
         "@sundaeswap/babel-preset": "workspace:*",
@@ -115,7 +113,7 @@
     },
     "packages/tailwind-config": {
       "name": "@sundaeswap/tailwind-config",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "dependencies": {
         "tailwindcss": "^4.0.0",
       },
@@ -2199,10 +2197,6 @@
     "postcss-reduce-initial": ["postcss-reduce-initial@7.0.1", "", { "dependencies": { "browserslist": "^4.23.1", "caniuse-api": "^3.0.0" }, "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-0JDUSV4bGB5FGM5g8MkS+rvqKukJZ7OTHw/lcKn7xPNqeaqJyQbUO8/dJpvyTpaVwPsd3Uc33+CfNzdVowp2WA=="],
 
     "postcss-reduce-transforms": ["postcss-reduce-transforms@7.0.0", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew=="],
-
-    "postcss-safe-parser": ["postcss-safe-parser@7.0.0", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg=="],
-
-    "postcss-scss": ["postcss-scss@4.0.9", "", { "peerDependencies": { "postcss": "^8.4.29" } }, "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ=="],
 


### PR DESCRIPTION
## Why

PR #44 (design-system-v4) merged to `main` but its **publish workflow failed at `bun install --frozen-lockfile`** — so `@sundaeswap/tailwind-config@5.x` and `@sundaeswap/postcss-config@3.x` were never published to npm (registry still serves 4.0.4 / 2.0.14). This blocks the downstream `ui-toolkit` and `dex-v2` CI from going green.

## Root cause

`bun.lock` was never regenerated after the v4 package.json changes:
- workspace `tailwind-config` was still pinned at **4.1.0** in the lock (package.json = **5.0.0**)
- orphaned `postcss-safe-parser` / `postcss-scss` entries lingered after postcss-config dropped them

The publish workflow's `setup-bun` floats to the latest bun (**1.3.14**), which validates the workspace version field under `--frozen-lockfile` and rejects the stale lock. Local bun 1.3.9 was lax about it, masking the drift.

## Fix

Regenerated `bun.lock` with bun 1.3.14 — a **1 insertion / 7 deletion** reconcile, no dependency bumps. Verified `bun install --frozen-lockfile` now passes under **both** 1.3.9 and 1.3.14, so there's no dev/CI ping-pong.

Merging this re-runs the publish workflow and ships tailwind-config@5.x + postcss-config@3.x — stage 1 of the design-system-v4 release chain (ui-toolkit and dex-v2 PRs follow once these are on npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)